### PR TITLE
Make readable error messages 25

### DIFF
--- a/Bcfier.Renga/AddViewRenga.xaml.cs
+++ b/Bcfier.Renga/AddViewRenga.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using Bcfier.Bcf.Bcf2;
+using Bcfier.Data.Utils;
 using Renga;
 
 namespace Bcfier.RengaPlugin
@@ -27,7 +28,7 @@ namespace Bcfier.RengaPlugin
       {
         image.SaveToFile(tempImg, Renga.ImageFormat.ImageFormat_PNG);
 
-        AddViewControl.AddViewpoint(tempImg);
+        AddViewControl.SnapshotImg.Source = ImagingUtils.ImageSourceFromPath(tempImg);
       }
       finally
       {

--- a/Bcfier.Renga/Data/RengaView.cs
+++ b/Bcfier.Renga/Data/RengaView.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows;
 using System.Windows.Media.Media3D;
 using Bcfier.Bcf.Bcf2;
 using Bcfier.Data.Utils;
@@ -98,7 +99,7 @@ namespace Bcfier.RengaPlugin.Data
       }
       catch (System.Exception ex1)
       {
-        app.UI.ShowMessageBox(Renga.MessageIcon.MessageIcon_Error, "Error!", ex1.Message);
+        MessageBox.Show(ex1.Message, "Error!");
       }
 
       return null;

--- a/Bcfier.Renga/Data/RengaView.cs
+++ b/Bcfier.Renga/Data/RengaView.cs
@@ -97,9 +97,9 @@ namespace Bcfier.RengaPlugin.Data
 
         return result;
       }
-      catch (System.Exception ex1)
+      catch (System.Exception ex)
       {
-        MessageBox.Show(ex1.Message, "Error!");
+        Utils.ShowErrorMessageBox("Create view point error.", ex);
       }
 
       return null;

--- a/Bcfier.Renga/Entry/ExtAppBcfier.cs
+++ b/Bcfier.Renga/Entry/ExtAppBcfier.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System;
 using System.Windows;
+using Bcfier.Data.Utils;
 
 namespace Bcfier.RengaPlugin.Entry
 {
@@ -27,22 +28,15 @@ namespace Bcfier.RengaPlugin.Entry
       }
       catch (Exception ex)
       {
-        MessageBox.Show(ex.ToString());
+        Utils.ShowErrorMessageBox("Unknown error.", ex);
       }
     }
 
     public void Focus()
     {
-      try
-      {
-        if (Window == null) return;
-        Window.Activate();
-        Window.WindowState = WindowState.Normal;
-      }
-      catch (Exception ex)
-      {
-        MessageBox.Show(ex.ToString());
-      }
+      if (Window == null) return;
+      Window.Activate();
+      Window.WindowState = WindowState.Normal;
     }
     #endregion
   }

--- a/Bcfier.Renga/Entry/ExtEvntOpenView.cs
+++ b/Bcfier.Renga/Entry/ExtEvntOpenView.cs
@@ -98,7 +98,7 @@ namespace Bcfier.RengaPlugin.Entry
       }
       catch (Exception ex)
       {
-        MessageBox.Show(ex.Message, "Error!");
+        Utils.ShowErrorMessageBox("Unknown error.", ex);
       }
     }
   }

--- a/Bcfier.Renga/Entry/ExtEvntOpenView.cs
+++ b/Bcfier.Renga/Entry/ExtEvntOpenView.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Windows;
 using Bcfier.Bcf.Bcf2;
 using Bcfier.Data.Utils;
 
@@ -97,7 +98,7 @@ namespace Bcfier.RengaPlugin.Entry
       }
       catch (Exception ex)
       {
-        app.UI.ShowMessageBox(Renga.MessageIcon.MessageIcon_Error, "Error!", ex.Message);
+        MessageBox.Show(ex.Message, "Error!");
       }
     }
   }

--- a/Bcfier.Renga/RengaWindow.xaml.cs
+++ b/Bcfier.Renga/RengaWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace Bcfier.RengaPlugin
       }
       catch (Exception ex1)
       {
-        app.UI.ShowMessageBox(Renga.MessageIcon.MessageIcon_Error, "Error!", ex1.Message);
+        MessageBox.Show(ex1.Message, "Error!");
       }
     }
 
@@ -72,7 +72,7 @@ namespace Bcfier.RengaPlugin
       }
       catch (System.Exception ex1)
       {
-        _App.UI.ShowMessageBox(Renga.MessageIcon.MessageIcon_Error, "Error!", ex1.Message);
+        MessageBox.Show(ex1.Message, "Error!");
       }
     }
     /// <summary>
@@ -90,14 +90,14 @@ namespace Bcfier.RengaPlugin
         var issue = e.Parameter as Markup;
         if (issue == null)
         {
-          _App.UI.ShowMessageBox(Renga.MessageIcon.MessageIcon_Error, "Error", "No Issue selected");
+          MessageBox.Show("No Issue selected", "Error");
           return;
         }
 
         var rengaActiveView = _App.ActiveView;
         if (rengaActiveView.Type != Renga.ViewType.ViewType_View3D)
         {
-          _App.UI.ShowMessageBox(Renga.MessageIcon.MessageIcon_Info, "Info", "Unsupported view");
+          MessageBox.Show("Unsupported view", "Info");
           return;
         }
 
@@ -118,7 +118,7 @@ namespace Bcfier.RengaPlugin
       }
       catch (System.Exception ex1)
       {
-        _App.UI.ShowMessageBox(Renga.MessageIcon.MessageIcon_Error, "Error!", ex1.Message);
+        MessageBox.Show(ex1.Message, "Error!");
       }
     }
     #endregion

--- a/Bcfier.Renga/RengaWindow.xaml.cs
+++ b/Bcfier.Renga/RengaWindow.xaml.cs
@@ -28,24 +28,17 @@ namespace Bcfier.RengaPlugin
       InitializeComponent();
       Bcfier.LabelVersion.Content = "BCFier for Renga " +
                          System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
-      try
+      _Handler = handler;
+      _App = app;
+
+      var applicationEvents = new Renga.ApplicationEventSource(_App);
+      applicationEvents.BeforeProjectClose += (eventArgs) =>
       {
-        _Handler = handler;
-        _App = app;
-        
-        var applicationEvents = new Renga.ApplicationEventSource(_App);
-        applicationEvents.BeforeProjectClose += (eventArgs) =>
-        {
-          if (Bcfier.TryCloseAllBcfs())
-            Close();
-          else
-            eventArgs.Prevent();
-        };
-      }
-      catch (Exception ex1)
-      {
-        MessageBox.Show(ex1.Message, "Error!");
-      }
+        if (Bcfier.TryCloseAllBcfs())
+          Close();
+        else
+          eventArgs.Prevent();
+      };
     }
 
     #region commands
@@ -70,9 +63,9 @@ namespace Bcfier.RengaPlugin
         _Handler.v = view.VisInfo;
         _Handler.Execute(_App);
       }
-      catch (System.Exception ex1)
+      catch (System.Exception ex)
       {
-        MessageBox.Show(ex1.Message, "Error!");
+        Utils.ShowErrorMessageBox("Open view error.", ex);
       }
     }
     /// <summary>
@@ -116,9 +109,9 @@ namespace Bcfier.RengaPlugin
         }
 
       }
-      catch (System.Exception ex1)
+      catch (System.Exception ex)
       {
-        MessageBox.Show(ex1.Message, "Error!");
+        Utils.ShowErrorMessageBox("Add view error.", ex);
       }
     }
     #endregion

--- a/Bcfier.Win/MainWindow.xaml.cs
+++ b/Bcfier.Win/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using Bcfier.Bcf.Bcf2;
 using WPFLocalizeExtension.Engine;
+using Bcfier.Data.Utils;
 
 
 namespace Bcfier.Win
@@ -67,9 +68,9 @@ namespace Bcfier.Win
           Bcfier.SelectedBcf().HasBeenSaved = false;
 
       }
-      catch (System.Exception ex1)
+      catch (System.Exception ex)
       {
-        MessageBox.Show("exception: " + ex1);
+        Utils.ShowErrorMessageBox("Add view error.", ex);
       }
     }
     #endregion

--- a/Bcfier/Bcf/BcfContainer.cs
+++ b/Bcfier/Bcf/BcfContainer.cs
@@ -21,7 +21,7 @@ namespace Bcfier.Bcf
   public class BcfContainer : INotifyPropertyChanged
   {
     private ObservableCollection<BcfFile> _bcfFiles { get; set; }
-    private int selectedReport { get; set; }
+    private int _selectedReport { get; set; }
 
     public BcfContainer()
     {
@@ -46,23 +46,20 @@ namespace Bcfier.Bcf
     {
       get
       {
-        return selectedReport;
+        return _selectedReport;
       }
 
       set
       {
-        selectedReport = value;
+        _selectedReport = value;
         NotifyPropertyChanged("SelectedReportIndex");
       }
     }
 
-
+    // Remove this
     public void NewFile()
     {
-      var newBcf = new BcfFile();
-      BcfFiles.Add(newBcf);
-      Directory.CreateDirectory(newBcf.TempPath);
-      SelectedReportIndex = BcfFiles.Count - 1;
+      AddBcf(new BcfFile());
     }
     public void SaveFile(BcfFile bcf)
     {
@@ -78,39 +75,39 @@ namespace Bcfier.Bcf
 
     public void OpenFile(string path)
     {
-      var newbcf = OpenBcfFile(path);
-      BcfOpened(newbcf);
+      var bcf = OpenBcfFile(path);
+      AddBcf(bcf);
     }
     public void OpenFile()
     {
-      var bcffiles = OpenBcfDialog();
-      if (bcffiles == null)
+      var bcfs = OpenBcfDialog();
+      if (bcfs == null)
         return;
-      foreach (var bcffile in bcffiles)
+      foreach (var bcf in bcfs)
       {
-        if (bcffile == null)
+        if (bcf == null)
           continue;
-        BcfOpened(bcffile);
+        AddBcf(bcf);
       }
     }
 
-    private void BcfOpened(BcfFile newbcf)
+    private void AddBcf(BcfFile newbcf)
     {
-      if (newbcf != null)
+      if (newbcf == null)
+        return;
+
+      BcfFiles.Add(newbcf);
+      SelectedReportIndex = BcfFiles.Count - 1;
+      if (newbcf.Issues.Any())
+        newbcf.SelectedIssue = newbcf.Issues.First();
+
+      foreach (var issue in newbcf.Issues)
       {
-        BcfFiles.Add(newbcf);
-        SelectedReportIndex = BcfFiles.Count - 1;
-        if (newbcf.Issues.Any())
-          newbcf.SelectedIssue = newbcf.Issues.First();
+        if (!Globals.OpenStatuses.Contains(issue.Topic.TopicStatus))
+          Globals.OpenStatuses.Add(issue.Topic.TopicStatus);
 
-        foreach (var issue in newbcf.Issues)
-        {
-          if (!Globals.OpenStatuses.Contains(issue.Topic.TopicStatus))
-            Globals.OpenStatuses.Add(issue.Topic.TopicStatus);
-
-          if (!Globals.OpenTypes.Contains(issue.Topic.TopicType))
-            Globals.OpenTypes.Add(issue.Topic.TopicType);
-        }
+        if (!Globals.OpenTypes.Contains(issue.Topic.TopicType))
+          Globals.OpenTypes.Add(issue.Topic.TopicType);
       }
     }
 

--- a/Bcfier/Bcf/BcfFile.cs
+++ b/Bcfier/Bcf/BcfFile.cs
@@ -220,9 +220,6 @@ namespace Bcfier.Bcf
 
     public void MergeBcfFile(IEnumerable<BcfFile> bcfFiles)
     {
-      try
-      {
-
         foreach (var bcf in bcfFiles)
         {
           foreach (var mergedIssue in bcf.Issues)
@@ -268,23 +265,12 @@ namespace Bcfier.Bcf
                   newView.Viewpoint = newView.Guid + ".bcfv";
                   File.Move(sourceFile, newView.SnapshotPath);
                   issue.Viewpoints.Add(newView);
-
-
                 }
             }
           }
           Utils.DeleteDirectory(bcf.TempPath);
         }
         HasBeenSaved = false;
-
-
-
-      }
-      catch (System.Exception ex1)
-      {
-        MessageBox.Show("exception: " + ex1);
-      }
-
     }
 
     [field: NonSerialized]

--- a/Bcfier/Data/AttachedProperties/NavigationService.cs
+++ b/Bcfier/Data/AttachedProperties/NavigationService.cs
@@ -81,9 +81,9 @@ namespace Bcfier.Data.AttachedProperties
       if (last_pos < new_text.Length)
         text_block.Inlines.Add(new Run(new_text.Substring(last_pos)));
       }
-      catch (System.Exception ex1)
+      catch (System.Exception)
       {
-        MessageBox.Show("exception: " + ex1);
+        // Log exception
       }
     }
 
@@ -91,12 +91,13 @@ namespace Bcfier.Data.AttachedProperties
     {
       var link = (Hyperlink)sender;
       // Do something with link.NavigateUri like:
-      try { 
+      try
+      {
         Process.Start(link.NavigateUri.ToString());
       }
-      catch (System.Exception ex1)
+      catch (System.Exception)
       {
-      Console.WriteLine(ex1.Message);
+        // Log exception
       }
     }
   }

--- a/Bcfier/Data/Utils/ImagingUtils.cs
+++ b/Bcfier/Data/Utils/ImagingUtils.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
@@ -15,231 +14,121 @@ namespace Bcfier.Data.Utils
     /// <returns></returns>
     public static ImageSource ImageSourceFromPath(string sourcePath)
     {
-
-      try
-      {
-        //var image = BitmapFromPath(sourcePath);
-        //return ConvertBitmapTo96Dpi(image);
-
-        var image = BitmapFromPath(sourcePath);
-        int width = image.PixelWidth;
-        int height = image.PixelHeight;
-
-        const int maxWidth = 1500;
-        const int maxHeight = 1500;
-        if (width > maxWidth || height > maxHeight)
-        {
-
-          double scale = (width > height) ? (double)width / (double)maxWidth : (double)height / (double)maxHeight;
-          int newHeight = Convert.ToInt32(height / scale);
-          int newWidth = Convert.ToInt32(width / scale);
-
-          MessageBoxResult answer = MessageBox.Show(
-            string.Format("Image size is {0}x{1}, "
-              + "such a big image could increase A LOT the BCF file size. "
-          + "Do you want me to resize it to {2}x{3} for you?", width, height, newWidth, newHeight), "Attention!",
-              MessageBoxButton.YesNo, MessageBoxImage.Question);
-          if (answer == MessageBoxResult.Yes)
-          {
-            width = newWidth;
-          }
-
-        }
-
-        byte[] imageBytes = LoadImageData(sourcePath);
-        return CreateImage(imageBytes, width, 0);
-
-      }
-      catch (System.Exception ex1)
-      {
-        MessageBox.Show("exception: " + ex1);
-      }
-      return null;
+      var image = BitmapFromPath(sourcePath);
+      int width = image.PixelWidth;
+      int height = image.PixelHeight;
+      byte[] imageBytes = LoadImageData(sourcePath);
+      return CreateImage(imageBytes, width, 0);
     }
 
     public static void SaveImageSource(ImageSource image, string destPath)
     {
-      try
-      {
-        var imageBytes = GetEncodedImageData(image, ".jpg");
-        SaveImageData(imageBytes, destPath);
-      }
-      catch (System.Exception ex1)
-      {
-        MessageBox.Show("exception: " + ex1);
-      }
+      var imageBytes = GetEncodedImageData(image, ".jpg");
+      SaveImageData(imageBytes, destPath);
     }
 
     public static BitmapImage BitmapFromPath(string path)
     {
-      try
-      {
-        var image = new BitmapImage();
-        image.BeginInit();
-        image.UriSource = new Uri(path);
-        image.CacheOption = BitmapCacheOption.OnLoad;
-        image.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
-        image.EndInit();
-        return image;
-      }
-      catch
-      {
-        return null;
-      }
-
+      var image = new BitmapImage();
+      image.BeginInit();
+      image.UriSource = new Uri(path);
+      image.CacheOption = BitmapCacheOption.OnLoad;
+      image.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
+      image.EndInit();
+      return image;
     }
     public static BitmapSource ConvertBitmapTo96Dpi(BitmapImage bitmapImage)
     {
-      try
-      {
-        double dpi = 96;
-        int width = bitmapImage.PixelWidth;
-        int height = bitmapImage.PixelHeight;
+      double dpi = 96;
+      int width = bitmapImage.PixelWidth;
+      int height = bitmapImage.PixelHeight;
+      int stride = width * 4; // 4 bytes per pixel
+      byte[] pixelData = new byte[stride * height];
+      bitmapImage.CopyPixels(pixelData, stride, 0);
 
-        if (width > 1500 || height > 1500)
-        {
-          string size = width.ToString() + "x" + height.ToString();
-          int newWidth = 1500;
-          float scale = (float)newWidth / ((float)width / (float)height);
-          int newHeight = Convert.ToInt32(scale);
-
-          MessageBoxResult answer = MessageBox.Show("Image size is " + size + ", "
-              + "such a big image could increase A LOT the BCF file size. "
-          + "Do you want me to resize it to " + newWidth.ToString() + "x" + newHeight.ToString() + " for you?", "Attention!",
-              MessageBoxButton.YesNo, MessageBoxImage.Question);
-          if (answer == MessageBoxResult.Yes)
-          {
-            width = newWidth;
-            height = newHeight;
-          }
-
-        }
-
-        int stride = width * 4; // 4 bytes per pixel
-        byte[] pixelData = new byte[stride * height];
-        bitmapImage.CopyPixels(pixelData, stride, 0);
-
-        return BitmapSource.Create(width, height, dpi, dpi, PixelFormats.Bgra32, null, pixelData, stride);
-      }
-
-      catch (System.Exception ex1)
-      {
-        MessageBox.Show("exception: " + ex1);
-      }
-      return null;
+      return BitmapSource.Create(width, height, dpi, dpi, PixelFormats.Bgra32, null, pixelData, stride);
     }
 
     private static byte[] LoadImageData(string filePath)
     {
-      try
-      {
-        FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-        BinaryReader br = new BinaryReader(fs);
-        byte[] imageBytes = br.ReadBytes((int)fs.Length);
-        br.Close();
-        fs.Close();
-        return imageBytes;
-      }
-      catch (System.Exception ex1)
-      {
-        MessageBox.Show("exception: " + ex1);
-      }
-      return null;
+      FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+      BinaryReader br = new BinaryReader(fs);
+      byte[] imageBytes = br.ReadBytes((int)fs.Length);
+      br.Close();
+      fs.Close();
+      return imageBytes;
     }
 
     private static ImageSource CreateImage(byte[] imageData, int decodePixelWidth, int decodePixelHeight)
     {
-      try
+      if (imageData == null) return null;
+      BitmapImage result = new BitmapImage();
+      result.BeginInit();
+      if (decodePixelWidth > 0)
       {
-        if (imageData == null) return null;
-        BitmapImage result = new BitmapImage();
-        result.BeginInit();
-        if (decodePixelWidth > 0)
-        {
-          result.DecodePixelWidth = decodePixelWidth;
-        }
-        if (decodePixelHeight > 0)
-        {
-          result.DecodePixelHeight = decodePixelHeight;
-        }
-        result.StreamSource = new MemoryStream(imageData);
-        result.CreateOptions = BitmapCreateOptions.None;
-        result.CacheOption = BitmapCacheOption.Default;
-        result.EndInit();
-        return result;
+        result.DecodePixelWidth = decodePixelWidth;
       }
-      catch (System.Exception ex1)
+      if (decodePixelHeight > 0)
       {
-        MessageBox.Show("exception: " + ex1);
+        result.DecodePixelHeight = decodePixelHeight;
       }
-      return null;
+      result.StreamSource = new MemoryStream(imageData);
+      result.CreateOptions = BitmapCreateOptions.None;
+      result.CacheOption = BitmapCacheOption.Default;
+      result.EndInit();
+      return result;
     }
 
     private static void SaveImageData(byte[] imageData, string filePath)
     {
-      try
-      {
-        FileStream fs = new FileStream(filePath, FileMode.Create,
-        FileAccess.Write);
-        BinaryWriter bw = new BinaryWriter(fs);
-        bw.Write(imageData);
-        bw.Close();
-        fs.Close();
-      }
-      catch (System.Exception ex1)
-      {
-        MessageBox.Show("exception: " + ex1);
-      }
+      FileStream fs = new FileStream(filePath, FileMode.Create,
+      FileAccess.Write);
+      BinaryWriter bw = new BinaryWriter(fs);
+      bw.Write(imageData);
+      bw.Close();
+      fs.Close();
     }
 
     private static byte[] GetEncodedImageData(ImageSource image, string preferredFormat)
     {
-      try
+      byte[] result = null;
+      BitmapEncoder encoder = null;
+      switch (preferredFormat.ToLower())
       {
-        byte[] result = null;
-        BitmapEncoder encoder = null;
-        switch (preferredFormat.ToLower())
-        {
-          case ".jpg":
-          case ".jpeg":
-            encoder = new JpegBitmapEncoder();
-            break;
-          case ".bmp":
-            encoder = new BmpBitmapEncoder();
-            break;
-          case ".png":
-            encoder = new PngBitmapEncoder();
-            break;
-          case ".tif":
-          case ".tiff":
-            encoder = new TiffBitmapEncoder();
-            break;
-          case ".gif":
-            encoder = new GifBitmapEncoder();
-            break;
-          case ".wmp":
-            encoder = new WmpBitmapEncoder();
-            break;
-        }
-        if (image is BitmapSource)
-        {
-          MemoryStream stream = new MemoryStream();
-          encoder.Frames.Add(BitmapFrame.Create(image as BitmapSource));
-          encoder.Save(stream);
-          stream.Seek(0, SeekOrigin.Begin);
-          result = new byte[stream.Length];
-          BinaryReader br = new BinaryReader(stream);
-          br.Read(result, 0, (int)stream.Length);
-          br.Close();
-          stream.Close();
-        }
-        return result;
+        case ".jpg":
+        case ".jpeg":
+          encoder = new JpegBitmapEncoder();
+          break;
+        case ".bmp":
+          encoder = new BmpBitmapEncoder();
+          break;
+        case ".png":
+          encoder = new PngBitmapEncoder();
+          break;
+        case ".tif":
+        case ".tiff":
+          encoder = new TiffBitmapEncoder();
+          break;
+        case ".gif":
+          encoder = new GifBitmapEncoder();
+          break;
+        case ".wmp":
+          encoder = new WmpBitmapEncoder();
+          break;
       }
-      catch (System.Exception ex1)
+      if (image is BitmapSource)
       {
-        MessageBox.Show("exception: " + ex1);
+        MemoryStream stream = new MemoryStream();
+        encoder.Frames.Add(BitmapFrame.Create(image as BitmapSource));
+        encoder.Save(stream);
+        stream.Seek(0, SeekOrigin.Begin);
+        result = new byte[stream.Length];
+        BinaryReader br = new BinaryReader(stream);
+        br.Read(result, 0, (int)stream.Length);
+        br.Close();
+        stream.Close();
       }
-      return null;
+      return result;
     }
   }
 }

--- a/Bcfier/Data/Utils/UserSettings.cs
+++ b/Bcfier/Data/Utils/UserSettings.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Configuration;
-using System.Windows;
 using System.Windows.Controls;
 using Bcfier.Themes;
 
@@ -23,7 +22,7 @@ namespace Bcfier.Data.Utils
           return string.Empty;
 
 
-        KeyValueConfigurationElement element = config.AppSettings.Settings[key];
+        var element = config.AppSettings.Settings[key];
         if (element != null)
         {
           string value = element.Value;
@@ -36,9 +35,9 @@ namespace Bcfier.Data.Utils
           config.Save(ConfigurationSaveMode.Modified);
         }
       }
-      catch (System.Exception ex1)
+      catch (System.Exception)
       {
-        MessageBox.Show("exception: " + ex1);
+        // Log exception
       }
       return string.Empty;
     }
@@ -64,9 +63,9 @@ namespace Bcfier.Data.Utils
         config.Save(ConfigurationSaveMode.Modified);
 
       }
-      catch (System.Exception ex1)
+      catch (System.Exception)
       {
-        MessageBox.Show("exception: " + ex1);
+        // Log exception
       }
     }
     /// <summary>
@@ -81,12 +80,12 @@ namespace Bcfier.Data.Utils
       try
       {
         //if it doesn't exist, use the optional default value
-        if(!Boolean.TryParse(Get(key), out value))
-        value = defValue;
+        if (!Boolean.TryParse(Get(key), out value))
+          value = defValue;
       }
-      catch (System.Exception ex1)
+      catch (System.Exception)
       {
-        MessageBox.Show("exception: " + ex1);
+        // Log exception
       }
       return value;
     }
@@ -101,15 +100,12 @@ namespace Bcfier.Data.Utils
       string _settings =
         System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "BCFier",
           "settings.config");
-      var configMap = new ExeConfigurationFileMap {ExeConfigFilename = _settings};
+      var configMap = new ExeConfigurationFileMap { ExeConfigFilename = _settings };
       var config = ConfigurationManager.OpenMappedExeConfiguration(configMap, ConfigurationUserLevel.None);
-
-      if (config == null)
-        MessageBox.Show("Error loading the Configuration file.", "Configuration Error", MessageBoxButton.OK, MessageBoxImage.Error);
       return config;
     }
 
-     /// <summary>
+    /// <summary>
     /// Tries to set user controls to what they were last time the user used the app
     /// </summary>
     public static void LoadControlSettings(Control control)
@@ -167,9 +163,9 @@ namespace Bcfier.Data.Utils
             tabcontrol.SelectedIndex = value;
         }
       }
-      catch (Exception ex)
+      catch (System.Exception)
       {
-        Console.Write(ex.Message);
+        // Log exception
       }
     }
     /// <summary>
@@ -217,9 +213,9 @@ namespace Bcfier.Data.Utils
           Set(tabcontrol.Name, tabcontrol.SelectedIndex.ToString());
         }
       }
-      catch (Exception ex)
+      catch (System.Exception)
       {
-        Console.Write(ex.Message);
+        // Log exception
       }
     }
   }

--- a/Bcfier/Data/Utils/Utils.cs
+++ b/Bcfier/Data/Utils/Utils.cs
@@ -80,11 +80,27 @@ namespace Bcfier.Data.Utils
             Directory.Delete(target_dir, false);
           }
         }
-        catch (System.Exception ex1)
-        {
-          MessageBox.Show("exception: " + ex1);
-        }
+      catch (System.Exception)
+      {
+        // Log exception
       }
-    
+    }
+    public static void ShowErrorMessageBox(string text, Exception ex = null)
+    {
+      var errorMessage = text;
+      if (ex != null)
+      {
+        errorMessage += Environment.NewLine;
+        errorMessage += Environment.NewLine;
+        errorMessage += ex.Message;
+      }
+
+      MessageBox.Show(errorMessage, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+
+    public static void ShowInfoMessageBox(string text)
+    {
+      MessageBox.Show(text, "Information", MessageBoxButton.OK, MessageBoxImage.Information);
+    }
   }
 }

--- a/Bcfier/Data/ValueConverters/PathToImageConv.cs
+++ b/Bcfier/Data/ValueConverters/PathToImageConv.cs
@@ -9,31 +9,26 @@ namespace Bcfier.Data.ValueConverters
   /// <summary>
   /// This avoids issues when deleting an image that is loaded by the UI
   /// </summary>
-    [ValueConversion(typeof(String), typeof(BitmapImage))]
-    public class PathToImageConv : IValueConverter
+  [ValueConversion(typeof(String), typeof(BitmapImage))]
+  public class PathToImageConv : IValueConverter
+  {
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-       
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value == null)
-                return null;
+      try
+      {
+        if (value == null)
+          return null;
 
-            if (!string.IsNullOrEmpty(value.ToString()))
-            {
-              return ImagingUtils.BitmapFromPath(value.ToString());
-            }
-
-            return null;
-
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-
-            throw new NotImplementedException();
-        }
-
-
-
+        var path = value.ToString();
+        return !string.IsNullOrEmpty(path) ? ImagingUtils.BitmapFromPath(path) : null;
+      }
+      catch { return null; }
     }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+      throw new NotImplementedException();
+    }
+  }
 }


### PR DESCRIPTION
Рефакторинг обработки ошибок:
- Убраны лишние сообщения об ошибках, в основном там, где можно просто не выполнить операцию без нарушения консистентности данных.
- Добавлено описание ошибки перед тем как показать текст исключения.
- Убрана обработка неожиданных ошибок во внутренних механизмах, стараюсь концентрировать "неожиданные" ошибки в UI обработчиках. Нужно стремиться к RAII работе с данными, поскольку отлов исключения не гарантирует сейчас в коде плагина, что данные остались в согласованном состоянии.