### PR TITLE
Add drawings markups

### DIFF
--- a/Bcfier.Renga/Bcfier.Renga.csproj
+++ b/Bcfier.Renga/Bcfier.Renga.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Entry\ExtEvntOpenView.cs" />
     <Compile Include="Entry\AppMain.cs" />
     <Compile Include="Data\RengaView.cs" />
+    <Compile Include="Entry\RengaEntityPath.cs" />
     <Compile Include="RengaWindow.xaml.cs">
       <DependentUpon>RengaWindow.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Bcfier.Renga/Data/RengaView.cs
+++ b/Bcfier.Renga/Data/RengaView.cs
@@ -1,16 +1,133 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows;
-using System.Windows.Media.Media3D;
-using Bcfier.Bcf.Bcf2;
-using Bcfier.Data.Utils;
+﻿using Bcfier.Localization;
+using Bcfier.RengaPlugin.Entry;
+using Renga;
+using System;
+
+using BcfPerspectiveCamera = Bcfier.Bcf.Bcf2.PerspectiveCamera;
+using BcfUtils = Bcfier.Data.Utils.Utils;
+using Component = Bcfier.Bcf.Bcf2.Component;
+using Components = Bcfier.Bcf.Bcf2.Components;
+using ComponentVisibility = Bcfier.Bcf.Bcf2.ComponentVisibility;
+using Vector3D = System.Windows.Media.Media3D.Vector3D;
+using VisualizationInfo = Bcfier.Bcf.Bcf2.VisualizationInfo;
 
 namespace Bcfier.RengaPlugin.Data
 {
   //Methods for working with views
   public static class RengaView
   {
+    private static Renga.IModel GetModel(Renga.IProject project, int entityId)
+    {
+      if (project.BuildingInfo.Id == entityId)
+        return project.Model;
+      if (project.Assemblies.Contains(entityId))
+        return project.Assemblies.GetById(entityId) as IModel;
+      if (project.Drawings2.Contains(entityId))
+        return project.Drawings2.GetById(entityId) as IModel;
+      return null;
+    }
+
+    private static Guid GetOwningEntityId(Renga.IProject project, int entityId)
+    {
+      if (project.BuildingInfo.Id == entityId)
+        return Guid.Empty;
+      if (project.Assemblies.Contains(entityId))
+        return project.Assemblies.GetById(entityId).UniqueId;
+      if (project.Drawings2.Contains(entityId))
+        return project.Drawings2.GetById(entityId).UniqueId;
+      return Guid.Empty;
+    }
+
+    private static Component CreateComponent(Guid uniqueId, Guid owningEntityId)
+    {
+      var rengaEntityPath = new RengaEntityPath(uniqueId, owningEntityId);
+      return new Component
+      {
+        IfcGuid = Bcfier.Data.Utils.IfcGuid.ToIfcGuid(uniqueId),
+        AuthoringToolId = rengaEntityPath.ToString()
+      };
+    }
+
+    private static ComponentVisibility BuildVisibility(IModel model, IModelView modelView, Guid owningEntityId)
+    {
+      var hiddenIds = modelView.GetHiddenObjects();
+      if (hiddenIds == null)
+        throw new System.Exception("IModelView.GetHiddenObjects returned null.");
+
+      if (hiddenIds.Length == 0)
+      {
+        return new ComponentVisibility
+        {
+          DefaultVisibilitySpecified = true,
+          DefaultVisibility = true,
+          Exceptions = Array.Empty<Component>()
+        };
+      }
+
+      var hiddenComponents = new Component[hiddenIds.Length];
+      for (int i = 0; i < hiddenIds.Length; i++)
+      {
+        var hiddenLocalId = (int)hiddenIds.GetValue(i);
+        var hiddenUniqueId = model.GetUniqueIdFromId(hiddenLocalId);
+        hiddenComponents[i] = CreateComponent(hiddenUniqueId, owningEntityId);
+      }
+
+      // Default visibility stays true because most scenes show the majority of objects.
+      return new ComponentVisibility
+      {
+        DefaultVisibilitySpecified = true,
+        DefaultVisibility = true,
+        Exceptions = hiddenComponents
+      };
+    }
+
+    private static Component[] BuildSelectionComponents(IModel model, Array selectedLocalIds, Guid owningEntityId)
+    {
+      if (selectedLocalIds == null || selectedLocalIds.Length == 0)
+        return Array.Empty<Component>();
+
+      var selection = new Component[selectedLocalIds.Length];
+      for (int i = 0; i < selectedLocalIds.Length; i++)
+      {
+        var selectedLocalId = (int)selectedLocalIds.GetValue(i);
+        var selectedGlobalId = model.GetUniqueIdFromId(selectedLocalId);
+        selection[i] = CreateComponent(selectedGlobalId, owningEntityId);
+      }
+
+      return selection;
+    }
+
+    private static BcfPerspectiveCamera CreateCameraParams(Renga.IView3DParams view3DParams)
+    {
+      var rengaCamera = view3DParams.Camera;
+      var bcfViewCamera = new BcfPerspectiveCamera();
+
+      // Position
+      bcfViewCamera.CameraViewPoint.X = rengaCamera.Position.X / 1000;
+      bcfViewCamera.CameraViewPoint.Y = rengaCamera.Position.Y / 1000;
+      bcfViewCamera.CameraViewPoint.Z = rengaCamera.Position.Z / 1000;
+
+      // Direction
+      var cameraVector = new Vector3D(
+        rengaCamera.FocusPoint.X - rengaCamera.Position.X,
+        rengaCamera.FocusPoint.Y - rengaCamera.Position.Y,
+        rengaCamera.FocusPoint.Z - rengaCamera.Position.Z);
+      cameraVector.Normalize();
+
+      bcfViewCamera.CameraDirection.X = cameraVector.X;
+      bcfViewCamera.CameraDirection.Y = cameraVector.Y;
+      bcfViewCamera.CameraDirection.Z = cameraVector.Z;
+
+      // Up
+      bcfViewCamera.CameraUpVector.X = rengaCamera.UpVector.X;
+      bcfViewCamera.CameraUpVector.Y = rengaCamera.UpVector.Y;
+      bcfViewCamera.CameraUpVector.Z = rengaCamera.UpVector.Z;
+
+      bcfViewCamera.FieldOfView = rengaCamera.FovHorizontal * (180 / Math.PI);
+
+      return bcfViewCamera;
+    }
+
     //<summary>
     //Generate a VisualizationInfo of the current view
     //</summary>
@@ -19,87 +136,38 @@ namespace Bcfier.RengaPlugin.Data
     {
       try
       {
-        var buildingModel = app.Project?.Model;
-        if (buildingModel == null)
+        if (app == null)
           return null;
 
-        var modelView = app.ActiveView as Renga.IModelView;
-        if (modelView == null)
+        var project = app.Project;
+        if (project == null)
           return null;
 
-        var view3DParams = modelView as Renga.IView3DParams;
-        if (view3DParams == null)
+        if (!(app.ActiveView is Renga.IModelView modelView))
           return null;
 
-        var rengaCamera = view3DParams.Camera;
-        var bcfViewCamera = new Bcfier.Bcf.Bcf2.PerspectiveCamera();
+        var entityId = modelView.RepresentedEntityId;
+        var model = GetModel(project, entityId);
+        if (model == null)
+          return null;
 
-        // Position
-        bcfViewCamera.CameraViewPoint.X = rengaCamera.Position.X / 1000;
-        bcfViewCamera.CameraViewPoint.Y = rengaCamera.Position.Y / 1000;
-        bcfViewCamera.CameraViewPoint.Z = rengaCamera.Position.Z / 1000;
+        var owningEntityId = GetOwningEntityId(project, entityId);
+        var visualization = new VisualizationInfo();
 
-        // Direction
-        var cameraVector = new Vector3D(
-          rengaCamera.FocusPoint.X - rengaCamera.Position.X, 
-          rengaCamera.FocusPoint.Y - rengaCamera.Position.Y, 
-          rengaCamera.FocusPoint.Z - rengaCamera.Position.Z);
-        cameraVector.Normalize();
+        if (modelView is Renga.IView3DParams view3DParams)
+          visualization.PerspectiveCamera = CreateCameraParams(view3DParams);
 
-        bcfViewCamera.CameraDirection.X = cameraVector.X;
-        bcfViewCamera.CameraDirection.Y = cameraVector.Y;
-        bcfViewCamera.CameraDirection.Z = cameraVector.Z;
-
-        // Up
-        bcfViewCamera.CameraUpVector.X = rengaCamera.UpVector.X;
-        bcfViewCamera.CameraUpVector.Y = rengaCamera.UpVector.Y;
-        bcfViewCamera.CameraUpVector.Z = rengaCamera.UpVector.Z;
-
-        bcfViewCamera.FieldOfView = rengaCamera.FovHorizontal * (180 / Math.PI);
-
-        var objects = buildingModel.GetObjects();
-        var hiddenComponents = new List<Component>();
-        foreach (int id in objects.GetIds())
+        visualization.Components = new Components
         {
-          if (modelView.IsObjectVisible(id))
-            continue;
+          Visibility = BuildVisibility(model, modelView, owningEntityId),
+          Selection = BuildSelectionComponents(model, app.Selection?.GetSelectedObjects(), owningEntityId)
+        };
 
-          var ifcGuid = IfcGuid.ToIfcGuid(objects.GetById(id).UniqueId);
-          var hiddenComponent = new Component();
-          hiddenComponent.IfcGuid = ifcGuid;
-          hiddenComponents.Add(hiddenComponent);
-        }
-
-        var result = new VisualizationInfo();
-        result.PerspectiveCamera = bcfViewCamera;
-        result.Components = new Components();
-        result.Components.Visibility = new ComponentVisibility();
-        // Here we believe that the default visibility should be "true"
-        // since this is widely the most common scenario.
-        // Although in some cases this may not be optimal.
-        // TODO: assess the number of visible and invisible objects
-        result.Components.Visibility.DefaultVisibilitySpecified = true;
-        result.Components.Visibility.DefaultVisibility = true;
-        result.Components.Visibility.Exceptions = hiddenComponents.ToArray();
-
-        // Selection
-        var selectedLocalIds = app.Selection.GetSelectedObjects();
-        result.Components.Selection = new Component[selectedLocalIds.Length];
-
-        for (int i = 0; i < selectedLocalIds.Length; i++)
-        {
-          var selectedLocalId = (int)selectedLocalIds.GetValue(i);
-          var selectedGlobalId = buildingModel.GetUniqueIdFromId(selectedLocalId);
-          var selectedComponent = new Component();
-          selectedComponent.IfcGuid = IfcGuid.ToIfcGuid(selectedGlobalId);
-          result.Components.Selection[i] = selectedComponent;
-        }
-
-        return result;
+        return visualization;
       }
       catch (System.Exception ex)
       {
-        Utils.ShowErrorMessageBox("Create view point error.", ex);
+        BcfUtils.ShowErrorMessageBox(LocValueGetter.Get("UnknownError"), ex);
       }
 
       return null;

--- a/Bcfier.Renga/Entry/ExtAppBcfier.cs
+++ b/Bcfier.Renga/Entry/ExtAppBcfier.cs
@@ -19,12 +19,9 @@ namespace Bcfier.RengaPlugin.Entry
         // If we do not have a dialog yet, create and show it  
         if (Window != null) return;
 
-        // A new handler to handle request posting by the dialog  
-        var handler = new ExtEvntOpenView();
-
         // We give the objects to the new dialog;  
         // The dialog becomes the owner responsible for disposing them, eventually.
-        Window = new RengaWindow(app, handler);
+        Window = new RengaWindow(app);
         Window.Show();
       }
       catch (Exception ex)

--- a/Bcfier.Renga/Entry/ExtEvntOpenView.cs
+++ b/Bcfier.Renga/Entry/ExtEvntOpenView.cs
@@ -1,57 +1,118 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Windows;
 using Bcfier.Bcf.Bcf2;
 using Bcfier.Data.Utils;
 using Bcfier.Localization;
+using Renga;
 
 namespace Bcfier.RengaPlugin.Entry
-{
+{ 
   public class ExtEvntOpenView
   {
+    static private string GetAnyAuthoringToolId(Components components)
+    {
+      // Here we use AuthoringToolId provided by BCF standard to contain full path to the Renga entity.
+      // Consider all Components belong to the same Renga entity
+
+      return components.Selection?.FirstOrDefault()?.AuthoringToolId 
+        ?? components.Visibility?.Exceptions?.FirstOrDefault()?.AuthoringToolId 
+        ?? components.Coloring?.FirstOrDefault(c => c.Component?.Length > 0)?.Component?.FirstOrDefault()?.AuthoringToolId 
+        ?? string.Empty;
+    }
+
+    static private Tuple<Renga.IModel, int> GetBuildingModelAndView(Renga.IProject project)
+    {
+      return new Tuple<Renga.IModel, int>(project.Model, project.BuildingInfo.Id);
+    }
+
+    static private Tuple<Renga.IModel, int> GetAssemblyModelAndView(Renga.IProject project, Guid id)
+    {
+      var assembly = project.Assemblies.GetByUniqueId(id);
+      return new Tuple<Renga.IModel, int>(assembly as Renga.IModel, assembly.Id);
+    }
+    static private Tuple<Renga.IModel, int> GetDrawingModelAndView(Renga.IProject project, Guid id)
+    {
+      var drawing = project.Drawings2.GetByUniqueId(id);
+      return new Tuple<Renga.IModel, int>(drawing as Renga.IModel, drawing.Id);
+    }
+
+    static private Tuple<Renga.IModel, int> GetModelAndView(Renga.IProject project, Components components)
+    {
+      // Building model is the default case
+      var anyAuthoringToolIdString = GetAnyAuthoringToolId(components);
+      if (anyAuthoringToolIdString == string.Empty)
+        return GetBuildingModelAndView(project);
+
+      var rengaEntityPath = new RengaEntityPath();
+      if (!RengaEntityPath.TryParse(anyAuthoringToolIdString, out rengaEntityPath))
+        return GetBuildingModelAndView(project);
+
+      if (rengaEntityPath.OwningEntityId == Guid.Empty)
+        return GetBuildingModelAndView(project);
+
+      if (project.Assemblies.ContainsUniqueId(rengaEntityPath.OwningEntityId))
+        return GetAssemblyModelAndView(project, rengaEntityPath.OwningEntityId);
+      else if (project.Drawings2.ContainsUniqueId(rengaEntityPath.OwningEntityId))
+        return GetDrawingModelAndView(project, rengaEntityPath.OwningEntityId);
+      else 
+        return GetBuildingModelAndView(project);
+    }
+    private Renga.IView OpenView(Guid entityId)
+    {
+      return null;
+    }
+
+    static private void SetCameraPosition(Renga.IModelView view, PerspectiveCamera bcfCamera)
+    {
+      var rengaCamera = (view as Renga.IView3DParams)?.Camera;
+      if (rengaCamera == null)
+        return;
+
+      var rengaCameraPos = new Renga.FloatPoint3D();
+      var bcfCameraPos = bcfCamera.CameraViewPoint;
+      rengaCameraPos.X = (float)bcfCameraPos.X * 1000;
+      rengaCameraPos.Y = (float)bcfCameraPos.Y * 1000;
+      rengaCameraPos.Z = (float)bcfCameraPos.Z * 1000;
+
+      var rengaFocusPoint = new Renga.FloatPoint3D();
+      var bcfCameraDirection = bcfCamera.CameraDirection;
+      rengaFocusPoint.X = rengaCameraPos.X + (float)bcfCameraDirection.X * 1000;
+      rengaFocusPoint.Y = rengaCameraPos.Y + (float)bcfCameraDirection.Y * 1000;
+      rengaFocusPoint.Z = rengaCameraPos.Z + (float)bcfCameraDirection.Z * 1000;
+
+      var rengaUpVector = new Renga.FloatVector3D();
+      var bcfUpVector = bcfCamera.CameraUpVector;
+      rengaUpVector.X = (float)bcfUpVector.X;
+      rengaUpVector.Y = (float)bcfUpVector.Y;
+      rengaUpVector.Z = (float)bcfUpVector.Z;
+      rengaCamera.LookAt(rengaFocusPoint, rengaCameraPos, rengaUpVector);
+    }
+
     static public void Execute(Renga.IApplication app, VisualizationInfo viewInfo)
     {
       try
       {
-        var modelView = app.ActiveView as Renga.IModelView;
+        if (app.Project == null)
+          return;
+
+        var owningModelAndView = GetModelAndView(app.Project, viewInfo.Components);
+        
+        var project = app.Project;
+        var model = owningModelAndView.Item1;
+
+        var view = app.OpenViewByEntity(owningModelAndView.Item2);
+        var modelView = view as Renga.IModelView;
+        
         if (modelView == null) 
           return;
 
-        var camera = (modelView as Renga.IView3DParams)?.Camera;
-        if (camera == null)
-          return;
-
-        if (viewInfo.PerspectiveCamera == null)
-          return;
-
-        var rengaCameraPos = new Renga.FloatPoint3D();
-        var bcfCameraPos = viewInfo.PerspectiveCamera.CameraViewPoint;
-        rengaCameraPos.X = (float)bcfCameraPos.X * 1000;
-        rengaCameraPos.Y = (float)bcfCameraPos.Y * 1000;
-        rengaCameraPos.Z = (float)bcfCameraPos.Z * 1000;
-
-        var rengaFocusPoint = new Renga.FloatPoint3D();
-        var bcfCameraDirection = viewInfo.PerspectiveCamera.CameraDirection;
-        rengaFocusPoint.X = rengaCameraPos.X + (float)bcfCameraDirection.X * 1000;
-        rengaFocusPoint.Y = rengaCameraPos.Y + (float)bcfCameraDirection.Y * 1000;
-        rengaFocusPoint.Z = rengaCameraPos.Z + (float)bcfCameraDirection.Z * 1000;
-
-        var rengaUpVector = new Renga.FloatVector3D();
-        var bcfUpVector = viewInfo.PerspectiveCamera.CameraUpVector;
-        rengaUpVector.X = (float)bcfUpVector.X;
-        rengaUpVector.Y = (float)bcfUpVector.Y;
-        rengaUpVector.Z = (float)bcfUpVector.Z;
-        camera.LookAt(rengaFocusPoint, rengaCameraPos, rengaUpVector);
-
-        var buildingModel = app.Project?.Model;
-        if (buildingModel == null)
-          return;
+        if (viewInfo.PerspectiveCamera != null)
+          SetCameraPosition(modelView, viewInfo.PerspectiveCamera);
 
         // Visibility
-        var allObjects = buildingModel.GetObjects();
-        var allObjectIds = buildingModel.GetObjects().GetIds();
+        var allObjects = model.GetObjects();
+        var allObjectIds = model.GetObjects().GetIds();
         var exceptionIds = new List<int>();
         var otherIds = new List<int>();
         var defaultVisibility = false;
@@ -90,14 +151,14 @@ namespace Bcfier.RengaPlugin.Entry
         foreach (var selectedComponent in viewInfo.Components.Selection)
         {
           var selectedObjectGlobalId = IfcGuid.FromIfcGUID(selectedComponent.IfcGuid);
-          var selectedObjectLocalId = buildingModel.GetIdFromUniqueId(selectedObjectGlobalId);
+          var selectedObjectLocalId = model.GetIdFromUniqueId(selectedObjectGlobalId);
           selectedObjectsLocalIds.Add(selectedObjectLocalId);
         }
         app.Selection.SetSelectedObjects(selectedObjectsLocalIds.ToArray());
       }
       catch (Exception ex)
       {
-        Utils.ShowErrorMessageBox(LocValueGetter.Get("UnknownError"), ex);
+        Bcfier.Data.Utils.Utils.ShowErrorMessageBox(LocValueGetter.Get("UnknownError"), ex);
       }
     }
   }

--- a/Bcfier.Renga/Entry/ExtEvntOpenView.cs
+++ b/Bcfier.Renga/Entry/ExtEvntOpenView.cs
@@ -11,9 +11,7 @@ namespace Bcfier.RengaPlugin.Entry
 {
   public class ExtEvntOpenView
   {
-    public VisualizationInfo v;
-
-    public void Execute(Renga.IApplication app)
+    static public void Execute(Renga.IApplication app, VisualizationInfo viewInfo)
     {
       try
       {
@@ -25,23 +23,23 @@ namespace Bcfier.RengaPlugin.Entry
         if (camera == null)
           return;
 
-        if (v.PerspectiveCamera == null)
+        if (viewInfo.PerspectiveCamera == null)
           return;
 
         var rengaCameraPos = new Renga.FloatPoint3D();
-        var bcfCameraPos = v.PerspectiveCamera.CameraViewPoint;
+        var bcfCameraPos = viewInfo.PerspectiveCamera.CameraViewPoint;
         rengaCameraPos.X = (float)bcfCameraPos.X * 1000;
         rengaCameraPos.Y = (float)bcfCameraPos.Y * 1000;
         rengaCameraPos.Z = (float)bcfCameraPos.Z * 1000;
 
         var rengaFocusPoint = new Renga.FloatPoint3D();
-        var bcfCameraDirection = v.PerspectiveCamera.CameraDirection;
+        var bcfCameraDirection = viewInfo.PerspectiveCamera.CameraDirection;
         rengaFocusPoint.X = rengaCameraPos.X + (float)bcfCameraDirection.X * 1000;
         rengaFocusPoint.Y = rengaCameraPos.Y + (float)bcfCameraDirection.Y * 1000;
         rengaFocusPoint.Z = rengaCameraPos.Z + (float)bcfCameraDirection.Z * 1000;
 
         var rengaUpVector = new Renga.FloatVector3D();
-        var bcfUpVector = v.PerspectiveCamera.CameraUpVector;
+        var bcfUpVector = viewInfo.PerspectiveCamera.CameraUpVector;
         rengaUpVector.X = (float)bcfUpVector.X;
         rengaUpVector.Y = (float)bcfUpVector.Y;
         rengaUpVector.Z = (float)bcfUpVector.Z;
@@ -58,18 +56,18 @@ namespace Bcfier.RengaPlugin.Entry
         var otherIds = new List<int>();
         var defaultVisibility = false;
 
-        if (v.Components.Visibility == null)
+        if (viewInfo.Components.Visibility == null)
         {
           otherIds = allObjectIds.OfType<int>().ToList();
         }
         else
         {
-          if (v.Components.Visibility.DefaultVisibilitySpecified)
-            defaultVisibility = v.Components.Visibility.DefaultVisibility;
+          if (viewInfo.Components.Visibility.DefaultVisibilitySpecified)
+            defaultVisibility = viewInfo.Components.Visibility.DefaultVisibility;
 
           Func<string, bool> isExceptionObject = (string ifcGuid) =>
           {
-            return Array.Find(v.Components.Visibility.Exceptions, exception => exception.IfcGuid == ifcGuid) != null;
+            return Array.Find(viewInfo.Components.Visibility.Exceptions, exception => exception.IfcGuid == ifcGuid) != null;
           };
 
           foreach (int id in allObjectIds)
@@ -89,7 +87,7 @@ namespace Bcfier.RengaPlugin.Entry
         // Selection
         var selectedObjectsLocalIds = new List<int>();
 
-        foreach (var selectedComponent in v.Components.Selection)
+        foreach (var selectedComponent in viewInfo.Components.Selection)
         {
           var selectedObjectGlobalId = IfcGuid.FromIfcGUID(selectedComponent.IfcGuid);
           var selectedObjectLocalId = buildingModel.GetIdFromUniqueId(selectedObjectGlobalId);

--- a/Bcfier.Renga/Entry/RengaEntityPath.cs
+++ b/Bcfier.Renga/Entry/RengaEntityPath.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+
+namespace Bcfier.RengaPlugin.Entry
+{
+  public class RengaEntityPath
+  {
+    public RengaEntityPath() { }
+
+    public RengaEntityPath(Guid entityId, Guid owningEntityId = new Guid())
+    {
+      OwningEntityId = owningEntityId;
+      EntityId = entityId;
+    }
+
+    static private string c_emptyInputErrorMsg = "Empty Renga entity path";
+    static private string c_invalidFormatErrorMsg = "Invalid Renga entity path format";
+    public static RengaEntityPath Parse(string pathString)
+    {
+      if (pathString == null || pathString.Length == 0)
+        throw new ArgumentNullException(c_emptyInputErrorMsg);
+
+      var matchFormatWithoutOwningEntity = Regex.Match(pathString, @"Renga\|([^|]+)$");
+      if (matchFormatWithoutOwningEntity.Success)
+        return new RengaEntityPath(Guid.Parse(matchFormatWithoutOwningEntity.Groups[1].Value));
+
+      var matchFormatWithOwningEntity = Regex.Match(pathString, @"Renga\|([^|]+)\|([^|]+)$");
+      if (matchFormatWithOwningEntity.Success)
+        return new RengaEntityPath(Guid.Parse(matchFormatWithOwningEntity.Groups[2].Value), Guid.Parse(matchFormatWithOwningEntity.Groups[1].Value));
+
+      throw new FormatException(c_invalidFormatErrorMsg);
+    }
+
+    static public bool TryParse(string pathString, out RengaEntityPath entityPath)
+    {
+      try
+      {
+        entityPath = Parse(pathString);
+        return true;
+      }
+      catch(ArgumentNullException) {entityPath = null; return false;}
+      catch (FormatException) { entityPath = null; return false; }
+    }
+
+    public override string ToString()
+    {
+      if (EntityId == Guid.Empty)
+        return string.Empty;
+      else if (OwningEntityId == Guid.Empty)
+        return $"Renga|{EntityId.ToString("D")}";
+      else
+        return $"Renga|{OwningEntityId.ToString("D")}|{EntityId.ToString("D")}";
+    }
+
+    public Guid OwningEntityId { get; set; }
+    public Guid EntityId { get; set; }
+  }
+}

--- a/Bcfier.Renga/RengaWindow.xaml.cs
+++ b/Bcfier.Renga/RengaWindow.xaml.cs
@@ -22,15 +22,14 @@ namespace Bcfier.RengaPlugin
   /// </summary>
   public partial class RengaWindow : Window
   {
-    private ExtEvntOpenView _Handler;
     private Renga.IApplication _App;
 
-    public RengaWindow(Renga.IApplication app, ExtEvntOpenView handler)
+    public RengaWindow(Renga.IApplication app)
     {
       InitializeComponent();
       m_panel.LabelVersion.Content = "BCFier for Renga " +
                          System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
-      _Handler = handler;
+      
       _App = app;
 
       var applicationEvents = new Renga.ApplicationEventSource(_App);
@@ -61,9 +60,8 @@ namespace Bcfier.RengaPlugin
         var view = e.Parameter as ViewPoint;
         if (view == null)
           return;
-        
-        _Handler.v = view.VisInfo;
-        _Handler.Execute(_App);
+
+        ExtEvntOpenView.Execute(_App, view.VisInfo);
       }
       catch (System.Exception ex)
       {

--- a/Bcfier.Renga/RengaWindow.xaml.cs
+++ b/Bcfier.Renga/RengaWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 
+using Renga;
 using Bcfier.Bcf.Bcf2;
 using Bcfier.RengaPlugin.Entry;
 using System.ComponentModel;
@@ -87,8 +88,9 @@ namespace Bcfier.RengaPlugin
           return;
         }
 
+        var supportedViews = new List<ViewType> { ViewType.ViewType_View3D, ViewType.ViewType_Assembly, ViewType.ViewType_Drawing };
         var rengaActiveView = _App.ActiveView;
-        if (rengaActiveView.Type != Renga.ViewType.ViewType_View3D)
+        if (!supportedViews.Contains(rengaActiveView.Type))
         {
           MessageBox.Show(LocValueGetter.Get("UnsupportedView"), LocValueGetter.Get("Info"));
           return;

--- a/Tests/TestRengaEntityPath.cs
+++ b/Tests/TestRengaEntityPath.cs
@@ -1,0 +1,193 @@
+﻿using NUnit.Framework;
+using Bcfier.RengaPlugin.Entry;
+using System;
+
+
+// Generated tests
+namespace Bcfier.RengaPlugin.Tests
+{
+  [TestFixture]
+  public class RengaEntityPathTests
+  {
+    [Test]
+    public void parse_valid_path_without_owning_entity_returns_correct_instance()
+    {
+      // given
+      var valid_path = "Renga|123e4567-e89b-12d3-a456-426614174000";
+      var expected_entity_id = new Guid("123e4567-e89b-12d3-a456-426614174000");
+
+      // when
+      var result = RengaEntityPath.Parse(valid_path);
+
+      // then
+      Assert.That(result.EntityId, Is.EqualTo(expected_entity_id));
+      Assert.That(result.OwningEntityId, Is.EqualTo(Guid.Empty));
+    }
+
+    [Test]
+    public void parse_valid_path_with_owning_entity_returns_correct_instance()
+    {
+      // given
+      var valid_path = "Renga|123e4567-e89b-12d3-a456-426614174000|abcdef12-3456-7890-abcd-ef1234567890";
+      var expected_owning_entity_id = new Guid("123e4567-e89b-12d3-a456-426614174000");
+      var expected_entity_id = new Guid("abcdef12-3456-7890-abcd-ef1234567890");
+
+      // when
+      var result = RengaEntityPath.Parse(valid_path);
+
+      // then
+      Assert.That(result.OwningEntityId, Is.EqualTo(expected_owning_entity_id));
+      Assert.That(result.EntityId, Is.EqualTo(expected_entity_id));
+    }
+
+    [Test]
+    public void parse_empty_string_throws_argument_null_exception()
+    {
+      // given
+      var empty_path = "";
+
+      // then
+      Assert.That(() => RengaEntityPath.Parse(empty_path),
+          Throws.Exception.TypeOf<ArgumentNullException>());
+    }
+
+    [Test]
+    public void parse_null_string_throws_argument_null_exception()
+    {
+      // given
+      string null_path = null;
+
+      // then
+      Assert.That(() => RengaEntityPath.Parse(null_path),
+          Throws.Exception.TypeOf<ArgumentNullException>());
+    }
+
+    [Test]
+    public void parse_invalid_format_throws_format_exception()
+    {
+      // given
+      var invalid_path = "Renga|123|456";
+
+      // then
+      Assert.That(() => RengaEntityPath.Parse(invalid_path),
+          Throws.Exception.TypeOf<FormatException>());
+    }
+
+    [Test]
+    public void try_parse_valid_path_returns_true_and_correct_instance()
+    {
+      // given
+      var valid_path = "Renga|123e4567-e89b-12d3-a456-426614174000|abcdef12-3456-7890-abcd-ef1234567890";
+      var result = default(RengaEntityPath);
+      var expected_owning_id = new Guid("123e4567-e89b-12d3-a456-426614174000");
+      var expected_entity_id = new Guid("abcdef12-3456-7890-abcd-ef1234567890");
+
+      // when
+      var success = RengaEntityPath.TryParse(valid_path, out result);
+
+      // then
+      Assert.That(success, Is.True);
+      Assert.That(result, Is.Not.Null);
+      Assert.That(result.OwningEntityId, Is.EqualTo(expected_owning_id));
+      Assert.That(result.EntityId, Is.EqualTo(expected_entity_id));
+    }
+
+    [Test]
+    public void to_string_empty_entity_returns_empty_string()
+    {
+      // given
+      var entityPath = new RengaEntityPath(Guid.Empty);
+
+      // when
+      var result = entityPath.ToString();
+
+      // then
+      Assert.That(result, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void to_string_without_owning_entity_returns_correct_format()
+    {
+      // given
+      var entityId = Guid.NewGuid();
+      var expectedString = $"Renga|{entityId.ToString("D")}";
+      var entityPath = new RengaEntityPath(entityId);
+
+      // when
+      var result = entityPath.ToString();
+
+      // then
+      Assert.That(result, Is.EqualTo(expectedString));
+    }
+
+    [Test]
+    public void to_string_with_owning_entity_returns_correct_format()
+    {
+      // given
+      var owningEntityId = Guid.NewGuid();
+      var entityId = Guid.NewGuid();
+      var expectedString = $"Renga|{owningEntityId.ToString("D")}|{entityId.ToString("D")}";
+      var entityPath = new RengaEntityPath(entityId, owningEntityId);
+
+      // when
+      var result = entityPath.ToString();
+
+      // then
+      Assert.That(result, Is.EqualTo(expectedString));
+    }
+
+    [Test]
+    public void to_string_and_parse_roundtrip_without_owning_entity_returns_equal_instance()
+    {
+      // given
+      var originalEntity = new RengaEntityPath(
+          entityId: Guid.Parse("a3dce496-21c5-4a6b-9e5f-19c27b4d3456")
+      );
+
+      // when
+      var serializedString = originalEntity.ToString();
+      var parsedEntity = RengaEntityPath.Parse(serializedString);
+
+      // then
+      Assert.That(parsedEntity.EntityId, Is.EqualTo(originalEntity.EntityId));
+      Assert.That(parsedEntity.OwningEntityId, Is.EqualTo(originalEntity.OwningEntityId));
+    }
+
+    [Test]
+    public void to_string_and_parse_roundtrip_with_owning_entity_returns_equal_instance()
+    {
+      // given
+      var originalEntity = new RengaEntityPath(
+          entityId: Guid.Parse("d9f7e2a1-5c8b-4d98-bc6a-03f89d1a2345"),
+          owningEntityId: Guid.Parse("b6c3a9d2-1e4f-4a7c-8d3b-0f5c98234567")
+      );
+
+      // when
+      var serializedString = originalEntity.ToString();
+      var parsedEntity = RengaEntityPath.Parse(serializedString);
+
+      // then
+      Assert.That(parsedEntity.EntityId, Is.EqualTo(originalEntity.EntityId));
+      Assert.That(parsedEntity.OwningEntityId, Is.EqualTo(originalEntity.OwningEntityId));
+    }
+
+    [Test]
+    public void to_string_and_try_parse_roundtrip_with_owning_entity_returns_equal_instance()
+    {
+      // given
+      var originalEntity = new RengaEntityPath(
+          entityId: Guid.NewGuid(),
+          owningEntityId: Guid.NewGuid()
+      );
+
+      // when
+      var serializedString = originalEntity.ToString();
+      var parseResult = RengaEntityPath.TryParse(serializedString, out var parsedEntity);
+
+      // then
+      Assert.That(parseResult, Is.True);
+      Assert.That(parsedEntity.EntityId, Is.EqualTo(originalEntity.EntityId));
+      Assert.That(parsedEntity.OwningEntityId, Is.EqualTo(originalEntity.OwningEntityId));
+    }
+  }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Bcfier.Renga\Bcfier.Renga.csproj" />
     <ProjectReference Include="..\Bcfier\Bcfier.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- Introduce RengaEntityPath and use it as a AuthoringToolId;
- Use RengaEntityPath as additional information to find object not only in a Building model but also in Drawings and Assemblies;
- Drawing markups works only for Renga. Obviously.